### PR TITLE
use https instead of http

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         }
         maven {
             name "mule-snapshots"
-            url "http://repository.mulesoft.org/nexus/content/repositories/snapshots/"
+            url "https://repository.mulesoft.org/nexus/content/repositories/snapshots/"
         }
     }
     dependencies {
@@ -35,11 +35,11 @@ repositories {
     mavenCentral()
     maven {
         name "mule-releases"
-        url "http://repository.mulesoft.org/nexus/content/repositories/releases/"
+        url "https://repository.mulesoft.org/nexus/content/repositories/releases/"
     }
     maven {
         name "mule-snapshots"
-        url "http://repository.mulesoft.org/nexus/content/repositories/snapshots/"
+        url "https://repository.mulesoft.org/nexus/content/repositories/snapshots/"
     }
 }
 


### PR DESCRIPTION
http was not allowed in Gradle 7.2. Either need to set the maven repo to allowInsecureProtocol, or change the mule repo URLs to https instead of http: 

maven {
url "http://**************"
allowInsecureProtocol = true
}