### PR TITLE
comment out testCompile method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,12 @@ repositories {
     }
 }
 
+/*
 dependencies {
     testCompile group: 'org.mule.weave', name: 'wtf', version: wtfVersion
     testCompile group: 'org.mule.weave', name: 'yaml-module', version: weaveVersion
 }
+*/
 
 task docs(type: Zip) {
     from 'src/main/docs/'


### PR DESCRIPTION
Using Gradle 7.2, build failed to find  testCompile method dependency, so commented out the dependency.  

What went wrong:
A problem occurred evaluating root project 'data-weave-tutorial-master'.
> Could not find method testCompile() for arguments [{group=org.mule.weave, name=wtf, version=1.0.3-SNAPSHOT}] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.