### PR TITLE
Fix DW-802: Changing retention policy on artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,4 +38,4 @@ jobs:
       with:
         name: weave-tutorial
         path: build/distributions/*.zip
-        retention-days: 5
+        retention-days: 90


### PR DESCRIPTION
Setting it to 90 days so we make sure the polling on the consumer repo will always find the artifact available