### PR TITLE
Update URL of supported formats documentation page

### DIFF
--- a/src/main/docs/1 - Introduction/1.2 - MIME Types/description.md
+++ b/src/main/docs/1 - Introduction/1.2 - MIME Types/description.md
@@ -1,6 +1,6 @@
 # 1.2 - MIME Types
 
-While DataWeave can handle itself when it comes to parsing and serializing data, it does need to be told what data to expect and generate. This is done by specifying MIME types for the inputs and output. MIME types specify the data format of a particular document, file, or piece of data. We use them to inform DataWeave what data format to read and write. There are many MIME types, but DataWeave only uses a [subset](https://docs.mulesoft.com/mule-runtime/latest/dataweave-formats) of them that make sense for its data transformation domain. Of that subset, we will be mainly focusing on 3 for this tutorial:
+While DataWeave can handle itself when it comes to parsing and serializing data, it does need to be told what data to expect and generate. This is done by specifying MIME types for the inputs and output. MIME types specify the data format of a particular document, file, or piece of data. We use them to inform DataWeave what data format to read and write. There are many MIME types, but DataWeave only uses a [subset](https://docs.mulesoft.com/dataweave/latest/dataweave-formats) of them that make sense for its data transformation domain. Of that subset, we will be mainly focusing on 3 for this tutorial:
 
 | Name | MIME Type        | ID     |
 | :--: |:----------------:| :-----:|


### PR DESCRIPTION
As DW now has a separated section (not nested under Mule Runtime docs) the former URL is responding 404.