### PR TITLE
Update URLs due to docs movement to separated section

### DIFF
--- a/src/main/docs/2 - Creating Data/description.md
+++ b/src/main/docs/2 - Creating Data/description.md
@@ -7,7 +7,7 @@ In this tutorial we will go over how to create:
 * Arrays
 * Objects
 
-These values have their respective [types](https://docs.mulesoft.com/mule-runtime/latest/dataweave-type-system):
+These values have their respective [types](https://docs.mulesoft.com/dataweave/latest/dataweave-type-system):
 * `Number`
 * `String`
 * `Boolean`

--- a/src/main/docs/3 - Reading Data/description.md
+++ b/src/main/docs/3 - Reading Data/description.md
@@ -2,7 +2,7 @@
 
 In the previous tutorial, we reviewed how you can create data using Strings, Numbers, Booleans, Arrays, and Objects. Creating data is only half of DataWeave, however; reading data is just as important, and the features available to do so are just as robust.
 
-DataWeave [selectors](https://docs.mulesoft.com/mule-runtime/latest/dataweave-selectors) allow navigating any combination of Objects and Arrays to get to the data you need. Throughout this tutorial we will review some of the most important ones:
+DataWeave [selectors](https://docs.mulesoft.com/dataweave/latest/dataweave-selectors) allow navigating any combination of Objects and Arrays to get to the data you need. Throughout this tutorial we will review some of the most important ones:
 
 * Single-value selector: `.`
 * Index selector: `[n]`

--- a/src/main/docs/4 - Variables & Logical Operators/description.md
+++ b/src/main/docs/4 - Variables & Logical Operators/description.md
@@ -4,4 +4,4 @@ In this tutorial we will go over two of the most critical tools we use when codi
 
 Variables are a way to store values with a given name so they can be later reused from different parts of your code, making the code cleaner and sometimes even more performant as values are calculated once.
 
-[Operators](https://docs.mulesoft.com/mule-runtime/latest/dw-operators) allow you to compare values and give you the basis to start making decisions with those comparisons.
+[Operators](https://docs.mulesoft.com/dataweave/latest/dw-operators) allow you to compare values and give you the basis to start making decisions with those comparisons.

--- a/src/main/docs/5 - Flow Control/description.md
+++ b/src/main/docs/5 - Flow Control/description.md
@@ -4,4 +4,4 @@ Flow control is used when you want to execute certain parts of your code in some
 
 In this tutorial we will go over some of the tools DataWeave offers for this, using what we learned on the previous one around logical operators.
 
-We'll go over if/else constructs and the basics of [pattern matching](https://docs.mulesoft.com/mule-runtime/latest/dataweave-pattern-matching). 
+We'll go over if/else constructs and the basics of [pattern matching](https://docs.mulesoft.com/dataweave/latest/dataweave-pattern-matching). 


### PR DESCRIPTION
As DW now has a separated section (not nested under Mule Runtime docs) the former URLs are responding 404.

This is a continuation of PR #22