### PR TITLE
Fix typo in 2.2 - Creating Data - Numbers

### DIFF
--- a/src/main/docs/2 - Creating Data/2.2 - Numbers/description.md
+++ b/src/main/docs/2 - Creating Data/2.2 - Numbers/description.md
@@ -16,7 +16,7 @@ output json
 ```
 ---
 
-## Excercise
+## Exercise
 Create a 4 decimal Pi representation.
 
 > Note what happens when you check its type using `typeOf`


### PR DESCRIPTION
Corrected typo from "Excercise" to "Exercise".